### PR TITLE
Add twitter.URL to list of required twitter values

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -18,6 +18,7 @@ include "twitter.conf"
 # twitter.consumer.secret=
 # twitter.accessToken.key=
 # twitter.accessToken.secret=
+# twitter.URL="https://stream.twitter.com/1.1/statuses/filter.json?track="
 
 elastic.TweetURL="http://localhost:9200/birdwatch_tech/tweets/"
 elastic.LogURL="http://localhost:9200/logstash-"


### PR DESCRIPTION
`twitter.URL` is required by `TwitterClient`. I have added the actual value there too as it's the same for every twitter application.

Fayi
