### PR TITLE
Process chunk from buffer in final step when assembling tweet chunks

### DIFF
--- a/Clojure-Websockets/TwitterClient/src/clj/birdwatch_tc/twitterclient/processing.clj
+++ b/Clojure-Websockets/TwitterClient/src/clj/birdwatch_tc/twitterclient/processing.clj
@@ -28,7 +28,7 @@
   (fn [step]
     (let [buff (atom "")]
       (fn
-        ([r] (step r))
+        ([r] (step r @buff))
         ([r x]
          (let [json-lines (-> (str @buff x)
                               (insert-newline)


### PR DESCRIPTION
In the final step the buff will contain the last chunk. The final step now ensures that the left over chunk is processed.
